### PR TITLE
Improve board texture filtering configuration

### DIFF
--- a/apps/web/app/components/Board3D.tsx
+++ b/apps/web/app/components/Board3D.tsx
@@ -314,12 +314,18 @@ function BoardRim({ size = 10, innerSize = 9.88, height = 0.04, color = '#000', 
 function ClickableBoardPlane({
     size, url, y, ...rest
 }: { size: number; url: string; y: number } & any) {
-    const texture = useLoader(THREE.TextureLoader, url)
+    const texture = useTexture(url)
     const { gl } = useThree()
-    const maxAniso = gl.capabilities.getMaxAnisotropy()
-    texture.anisotropy = Math.max(8, maxAniso)
-    texture.minFilter = THREE.LinearMipmapLinearFilter
-    texture.magFilter = THREE.LinearFilter
+    const tex: THREE.Texture = Array.isArray(texture)
+        ? (texture[0] as THREE.Texture)
+        : (texture as THREE.Texture)
+    const maxAniso = (gl.capabilities as any)?.getMaxAnisotropy?.() ?? 16
+    tex.colorSpace = THREE.SRGBColorSpace
+    tex.generateMipmaps = true
+    tex.anisotropy = Math.max(8, maxAniso)
+    tex.minFilter = THREE.LinearMipmapLinearFilter
+    tex.magFilter = THREE.LinearFilter
+    tex.needsUpdate = true
     return (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, y, 0]} receiveShadow {...rest}>
             <planeGeometry args={[size, size]} />


### PR DESCRIPTION
## Summary
- switch the board plane to use `useTexture` and safely narrow the returned type
- configure sRGB color space, mipmaps, anisotropy, and filtering with guards for renderer capabilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51b6ea59083279a25bc5c13aed0eb