### PR TITLE
Fix production socket defaults and Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ cd C:\\Users\\sonat\\Desktop\\monopolytr\\monopoly
 pnpm -C apps/server dev
 ```
 
+To enable development-only helpers such as flushing in-memory rooms, set `DEV_ENABLE_FLUSH=1` when running the server. Once enabled, send a `POST` request to `http://127.0.0.1:8787/dev/flush` to clear all rooms and timers.
+
+When deploying the client, point `NEXT_PUBLIC_SOCKET_URL` (and optionally `NEXT_PUBLIC_API_URL`) to your hosted game server. The default production build uses the Render deployment at `https://monopoly-socket-server.onrender.com`.
+
 ## Terminal 2
 
 ```

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -13,6 +13,8 @@ app.use(cors({ origin: ALLOWED, credentials: false }))
 app.get('/health', (_req: Request, res: Response) => res.send('ok'))
 app.get('/server', (_req, res) => res.send('monopoly server is up'));
 
+const DEV_ENABLE_FLUSH = ['1', 'true', 'yes'].includes((process.env.DEV_ENABLE_FLUSH || '').toLowerCase())
+
 // List rooms with at least one player
 app.get('/rooms', (_req: Request, res: Response) => {
   try {
@@ -82,6 +84,20 @@ function autoPass(rid: string, at: number, forId: string) {
     // Schedule for next player's turn (if still in play)
     scheduleTurnTimer(rid)
   }
+}
+
+if (DEV_ENABLE_FLUSH) {
+  app.post('/dev/flush', (_req: Request, res: Response) => {
+    const roomIds = Object.keys(rooms)
+    for (const rid of roomIds) {
+      clearTurnTimer(rid)
+      delete turnTimers[rid]
+      delete timerMeta[rid]
+      delete lastActionAt[rid]
+      delete rooms[rid]
+    }
+    res.json({ ok: true, deleted: roomIds.length })
+  })
 }
 
 io.on('connection', (socket) => {

--- a/apps/web/lib/socket.ts
+++ b/apps/web/lib/socket.ts
@@ -1,7 +1,13 @@
 import { io } from 'socket.io-client'
 
-// Use 127.0.0.1 to avoid some localhost resolution quirks on Windows
-const url = process.env.NEXT_PUBLIC_SOCKET_URL ?? 'http://127.0.0.1:8787'
+// Default to the Render deployment when we're in production, otherwise assume
+// local development (which still prefers overriding via NEXT_PUBLIC_SOCKET_URL).
+const DEFAULT_REMOTE = 'https://monopoly-socket-server.onrender.com'
+const DEFAULT_LOCAL = 'http://127.0.0.1:8787'
+
+const url =
+  process.env.NEXT_PUBLIC_SOCKET_URL ??
+  (process.env.NODE_ENV === 'production' ? DEFAULT_REMOTE : DEFAULT_LOCAL)
 
 // Force websocket (skip polling that’s failing)
 // If you deploy later, you can remove the transports override.

--- a/render.yaml
+++ b/render.yaml
@@ -6,8 +6,9 @@ services:
     plan: free
     buildCommand: |
       corepack enable
-      pnpm i --frozen-lockfile
-    startCommand: node server.js
+      pnpm install --frozen-lockfile
+      pnpm run build
+    startCommand: pnpm start
     envVars:
       - key: NODE_ENV
         value: production


### PR DESCRIPTION
## Summary
- point the client to the Render-hosted socket server by default in production builds
- fix the Render deployment to install dependencies, build TypeScript, and start via the package script
- document the expected environment variables for the hosted game server in the README

## Testing
- pnpm -C apps/server build
- pnpm -C apps/web build *(fails: unable to download Inter font due to network restrictions in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5366c4d5c832786f6deec626f4716